### PR TITLE
New __hash__ implementation up to documentation standards

### DIFF
--- a/flexdict/__init__.py
+++ b/flexdict/__init__.py
@@ -34,13 +34,12 @@ class FlexDict(dict):
                 )
 
     def __hash__(self):
-        def mul(l):
-            rv = 1
-            for i in l:
-                rv *= i
-            return rv
+        import hashlib
         locked_state = "l" if self.locked else "u"
-        return mul([ord(c) for c in str(self.flatten()) + locked_state])
+        hasher = hashlib.sha1()
+        for char in str(self) + locked_state:
+            hasher.update(char)
+        return hasher.hexdigest()
 
     def __eq__(self, other):
         if isinstance(other, dict):

--- a/flexdict/__init__.py
+++ b/flexdict/__init__.py
@@ -34,7 +34,13 @@ class FlexDict(dict):
                 )
 
     def __hash__(self):
-        return id(self)
+        def mul(l):
+            rv = 1
+            for i in l:
+                rv *= i
+            return rv
+        locked_state = "l" if self.locked else "u"
+        return mul([ord(c) for c in str(self.flatten()) + locked_state])
 
     def __eq__(self, other):
         if isinstance(other, dict):

--- a/tests/test.py
+++ b/tests/test.py
@@ -46,6 +46,17 @@ def test_equals():
     assert (flex is FlexDict()) is False
 
 
+def test_hash_equals():
+    """Hash equality comparisons. hash(FlexDict()) == hash(FlexDict())"""
+    f = FlexDict()
+    g = FlexDict()
+    assert (hash(f) == hash(g)) is True
+    assert (hash(f) == hash(f)) is True
+    f["foo", "bar"] = 1
+    g["bar", "foo"] = 1
+    assert (hash(f) == hash(g)) is False
+
+
 @mark.parametrize(
     'keys', [
         ['a'],


### PR DESCRIPTION
hash(FlexDict()) should equal to hash(FlexDict()) which doesn't happen with the current implementation.

This proposed change should work most of the time, but there may be some hash conflicts. Algorithm used is SHA1 since it's relatively fast, and readily available on all platforms.